### PR TITLE
Destructure props only after making create request

### DIFF
--- a/src/containers/users/UserForm.jsx
+++ b/src/containers/users/UserForm.jsx
@@ -103,11 +103,11 @@ export class UserForm extends Component {
           };
 
           try {
-            const { errorMessage } = this.props;
-            const { hasError } = this.props;
             const { formActionDispatch } = this.props;
             formActionDispatch(payload, this.targetId).then(() => {
               setSubmitting(false);
+              const { errorMessage } = this.props;
+              const { hasError } = this.props;
               if (hasError) {
                 setErrors(transformMyApiErrors(errorMessage));
               } else {


### PR DESCRIPTION
After the call to `formActionDispatch` is made, a new state object is create. `hasError` and `errorMessage` remain pointing to the old state which has stale data.

fixes onaio/kaznet-web#338