### PR TITLE
Fix Issue where form would be missing from state

### DIFF
--- a/src/services/forms.js
+++ b/src/services/forms.js
@@ -1,7 +1,8 @@
+/* eslint-disable class-methods-use-this */
 import _ from 'lodash';
 import * as constants from '../constants';
 
-class formService {
+class FormService {
   async getFormList(url = `${constants.API_ENDPOINT}/forms/?format=vnd.api%2Bjson`) {
     const response = await fetch(url, {
       method: 'GET',
@@ -36,6 +37,30 @@ class formService {
       totalCount: count
     };
   }
+
+  async getForm(id) {
+    const url = `${constants.API_ENDPOINT}/forms/${id}/?format=vnd.api%2Bjson`;
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/vnd.api+json',
+        Authorization: `Token ${constants.API_TOKEN}`
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error(`FormService getForm failed, HTTP status ${response.status}`);
+    }
+
+    const { data } = await response.json();
+
+    if (!data) {
+      throw new Error(`FormService getForm failed, HTTP status ${response.status}`);
+    }
+
+    return data;
+  }
 }
 
-export default new formService();
+export default new FormService();

--- a/src/store/forms/actionTypes.js
+++ b/src/store/forms/actionTypes.js
@@ -2,3 +2,4 @@
 export const FORMS_FETCHED = 'forms.FORMS_FETCHED';
 export const FORM_CHANGE_PAGE = 'forms.FORM_CHANGE_PAGE';
 export const FORM_HAS_TASK = 'forms.FORM_HAS_TASK';
+export const FORM_FETCHED = 'forms.FORM_FETCHED';

--- a/src/store/forms/actions.js
+++ b/src/store/forms/actions.js
@@ -5,7 +5,7 @@ import formService from '../../services/forms';
 
 // get list of forms
 export function fetchForms(url) {
-  return async (dispatch, getState) => {
+  return async dispatch => {
     try {
       const {
         formArray,
@@ -40,7 +40,7 @@ export function fetchForms(url) {
 }
 
 export function changePageNumber(pageNumber) {
-  return async (dispatch, getState) => {
+  return async dispatch => {
     dispatch({
       type: types.FORM_CHANGE_PAGE,
       pageNumber
@@ -54,5 +54,16 @@ export function getHasTask(hasTask) {
       type: types.FORM_HAS_TASK,
       hasTask
     });
+  };
+}
+
+export function fetchForm(id) {
+  return async dispatch => {
+    try {
+      const formData = await formService.getForm(id);
+      dispatch({ type: types.FORM_FETCHED, formData });
+    } catch (error) {
+      console.error(error);
+    }
   };
 }

--- a/src/store/forms/reducer.js
+++ b/src/store/forms/reducer.js
@@ -43,6 +43,14 @@ export default function reduce(state = initialState, action = {}) {
         ...state,
         hasTask: action.hasTask
       });
+    case types.FORM_FETCHED:
+      return Immutable({
+        ...state,
+        formsById: {
+          ...state.formsById,
+          [action.formData.id]: action.formData
+        }
+      });
     default:
       return state;
   }


### PR DESCRIPTION
While editing a task whose form hasn't been loaded into state and error is raised and not handled gracefully.

This PR implements form retrieval in order to retrieve specific tasks when missing from state.